### PR TITLE
feat: Add Gamemode One add-ons to registry

### DIFF
--- a/registry.js
+++ b/registry.js
@@ -66,4 +66,12 @@ export const Registry = {
         name: "Epic Fantasy",
         creator: "Waypoint Studios",
     },
+    gm1_ord: {
+        name: "Sonic",
+        creator: "Gamemode One",
+    },
+    gm1_zen: {
+        name: "How to Train Your Dragon",
+        creator: "Gamemode One",
+    },
 };


### PR DESCRIPTION
Adds Gamemode One's add-ons to the registry.
- `gm1_ord` -> Sonic Add-On
- `gm1_zen` -> How to Train Your Dragon Add-On (HTTYD Add-On)